### PR TITLE
Add in documentation for tagged template strings

### DIFF
--- a/api-browser-es5.js
+++ b/api-browser-es5.js
@@ -294,12 +294,13 @@ browser.onRender = function () {
   };
 
   var update = function update() {
-    var screenHeight = window.innerHeight / 2;
+    // Bring back some of the padding, so we can see the section title...
+    scrollTop = document.body.scrollTop + 60;
 
-    scrollTop = document.body.scrollTop;
-
-    headerTable.some(function (meta) {
-      if (meta.top >= scrollTop - screenHeight) {
+    headerTable.sort(function (a, b) {
+      return b.top - a.top;
+    }).some(function (meta) {
+      if (scrollTop > meta.top) {
         clearAll();
 
         if (scrollTop) {

--- a/api-browser.js
+++ b/api-browser.js
@@ -293,12 +293,11 @@ browser.onRender = () => {
   };
 
   const update = () => {
-    const screenHeight = window.innerHeight / 2;
+    // Bring back some of the padding, so we can see the section title...
+    scrollTop = document.body.scrollTop + 60;
 
-    scrollTop = document.body.scrollTop;
-
-    headerTable.some(meta => {
-      if (meta.top >= (scrollTop - screenHeight)) {
+    headerTable.sort((a, b) => b.top - a.top).some(meta => {
+      if (scrollTop > meta.top) {
         clearAll();
 
         if (scrollTop) {

--- a/styles.css
+++ b/styles.css
@@ -341,6 +341,10 @@ section#content a:not(.header):hover {
   border-bottom: 2px solid #a0a0a0;
 }
 
+section#content a.no-underline {
+  border-bottom: none !important;
+}
+
 section#content a.header {
   text-decoration: none;
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -580,3 +580,7 @@ layer {
 		white-space: nowrap;
 	}
 }
+
+.hljs-string .hljs-subst {
+  color: #d405a7;
+}

--- a/template.html
+++ b/template.html
@@ -36,20 +36,24 @@
         <li class="header"><h4>Concepts</h4></li>
 
         <a href="#virtual-trees"><li>Virtual trees</li></a>
+        <a href="#tagged-templates"><li>Tagged templates</li></a>
         <a href="#object-pooling"><li>Object pooling</li></a>
         <a href="#render-transaction"><li>Render transactions</li></a>
-        <a href="#tagged-templates"><li>Tagged templates</li></a>
         <a href="#transitions"><li>Transitions</li></a>
         <a href="#middleware"><li>Middleware</li></a>
 
         <li class="header"><h4>Middleware</h4></li>
         <a href="#logging"><li>Logging</li></a>
-        <a href="#inline-transition-hooks"><li>Inline transition hooks</li></a>
+        <a href="#devtools"><li>Chrome DevTools</li></a>
+        <a href="#synthetic-events"><li>Synthetic Events (Delegation)</li></a>
+        <a href="#inline-transitions"><li>Inline transitions</li></a>
+        <a href="#verify-state"><li>Verify State (Debugging)</li></a>
 
         <li class="header"><h4>External tools</h4></li>
 
-        <a href="#transpiler"><li>Babel transform</li></a>
+        <a href="#transpiler"><li>Babel transforms</li></a>
         <a href="#prollyfill"><li>Browser prollyfill</li></a>
+        <a href="#components"><li>Web and Vanilla Components (React-Inspired)</li></a>
 
         <li class="header"><h4>Examples</h4></li>
 
@@ -316,27 +320,70 @@
       efficient.
     </p>
 
-    <a class="header" href="#object-pooling"><h3 id="object-pooling">Object pooling</h3></a>
-    <p>Coming soon...</p>
-
-    <a class="header" href="#render-transaction"><h3 id="render-transaction">Render transactions</h3></a>
-    <p>Coming soon...</p>
-
     <a class="header" href="#tagged-templates"><h3 id="tagged-templates">Tagged templates</h3></a>
 
     <p>
-      <a
+      With the release of ES-2015, <a
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals">Tagged
-      template helpers</a> are an ES-2015 compliant function that are used with
-      <a
-      href="https://developers.google.com/web/updates/2015/01/ES6-Template-Strings?hl=en">template
-      strings</a> in order to parse and manipulate a new value from declarative
-      strings and interpolated values. The helper in diffHTML is named <a
-      href="#html">html</a>, because it parses well formed HTML into a Virtual
-      Tree that is then used internally to determine changes.
+      template helpers</a> were introduced as a way to transform strings and
+      data. This feature makes it easy to write multiline strings required for
+      use cases like: inline HTML, CSS, and JSON. diffHTML utilizes them for
+      parsing HTML into <a href="#virtual-trees">Virtual Trees</a>.
     </p>
+
     <p>
-      The usage looks like this:
+      <strong>Native JSON parsing example:</strong>
+
+      <pre><code class="javascript">const obj = JSON.parse`{
+  "nodeName": "div",
+  "attributes": [
+    { "id": "main" }
+  ]
+}`;
+
+console.log(obj.attributes.id); // "main"</code></pre>
+    </p>
+
+    <p>
+      The helper in diffHTML is named <a href="#html">html</a>, because it
+      parses well formed HTML into a Virtual Tree which is then used internally
+      to reconcile changes. This helper can be used for simple HTML strings,
+      complex stateful components, nested DOM nodes, event handlers, form
+      inputs, and passing of complex data to custom elements.
+    </p>
+
+    <p>
+      <strong>Importing the HTML helper:</strong>
+
+      <pre><code class="javascript">import { html } from 'diffhtml';</code></pre>
+    </p>
+
+    <p>
+      <strong>HTML parsing example:</strong>
+
+      <pre><code class="javascript">const vTree = html`&lt;div&gt;Hello world!&lt;/div&gt;`;</code></pre>
+    </p>
+
+    <p>
+      <strong>Nesting Virtual Trees:</strong>
+
+      <pre><code class="javascript">import { html } from 'diffhtml';
+
+const vTree = html`&lt;div&gt;${html`&lt;span&gt;Hello world&lt;/span&gt;`}&lt;/div&gt;`;</code></pre>
+    </p>
+
+    <p>
+      <strong>Markup is escaped by default:</strong>
+
+      <pre><code class="javascript">import { html } from 'diffhtml';
+
+const vTree = html`${
+  "&lt;script&gt;window.alert('This will not work');&lt;/script&gt;"
+}`</code></pre>
+    </p>
+
+    <p>
+      <strong>Stateless component example:</strong>
 
       <pre><code class="javascript">import { html, innerHTML } from 'diffhtml';
 
@@ -362,6 +409,7 @@ setInterval(() => {
     </p>
 
     <p></p>
+
     <a class="header" href="#inspiration"><h4 id="inspiration">Inspiration</h4></a>
 
     <p>
@@ -399,6 +447,13 @@ setInterval(() => {
     </p>
     
     <a class="header" href="#transitions"><h3 id="transitions">Transitions</h3></a>
+    <p>Coming soon...</p>
+
+
+    <a class="header" href="#object-pooling"><h3 id="object-pooling">Object pooling</h3></a>
+    <p>Coming soon...</p>
+
+    <a class="header" href="#render-transaction"><h3 id="render-transaction">Render transactions</h3></a>
     <p>Coming soon...</p>
 
     <a class="header" href="#middleware"><h3 id="middleware">Middleware</h3></a>

--- a/template.html
+++ b/template.html
@@ -317,15 +317,52 @@
     </p>
 
     <a class="header" href="#object-pooling"><h3 id="object-pooling">Object pooling</h3></a>
-
-    <p>
-      One of the most  
-    </p>
+    <p>Coming soon...</p>
 
     <a class="header" href="#render-transaction"><h3 id="render-transaction">Render transactions</h3></a>
     <p>Coming soon...</p>
 
     <a class="header" href="#tagged-templates"><h3 id="tagged-templates">Tagged templates</h3></a>
+
+    <p>
+      <a
+      href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals">Tagged
+      template helpers</a> are an ES-2015 compliant function that are used with
+      <a
+      href="https://developers.google.com/web/updates/2015/01/ES6-Template-Strings?hl=en">template
+      strings</a> in order to parse and manipulate a new value from declarative
+      strings and interpolated values. The helper in diffHTML is named <a
+      href="#html">html</a>, because it parses well formed HTML into a Virtual
+      Tree that is then used internally to determine changes.
+    </p>
+    <p>
+      The usage looks like this:
+
+      <pre><code class="javascript">import { html, innerHTML } from 'diffhtml';
+
+const timeComponent = ({ hours, minutes, seconds }) => html`&lt;div class="time-component"&gt;
+  &lt;span&gt;The time is: ${hours}:${minutes}:${seconds}&lt;/span&gt;
+&lt;/div&gt;`;
+
+// Update the time every second.
+setInterval(() => {
+  const now = new Date();
+
+  innerHTML(document.body, timeComponent({
+    hours: now.getHours(),
+    minutes: now.getMinutes(),
+    seconds: now.getSeconds(),
+  }));
+}, 1000);</code></pre>
+    </p>
+    <p>
+      This helper is smart too, meaning it can handle event binding, any
+      key/value on any element, composing existing DOM nodes, and can even be
+      pre-compiled directly into functions using Babel!
+    </p>
+
+    <p></p>
+    <a class="header" href="#inspiration"><h4 id="inspiration">Inspiration</h4></a>
 
     <p>
       JSX has shown that developers like to declaratively describe their UI in
@@ -342,12 +379,25 @@
       isn't exactly HTML per-se, but a similar flavor that leans closer to
       strict XHTML than HTML. It also deals purely with properties and not
       attributes. This is fairly far and away from standards and to use JSX
-      effectively you'll need to align your tooling around it.
+      effectively you'll need to align your tooling and awareness around its
+      differences. For instance, attributes like <code>class</code> will need
+      to be substituted for <code>className</code>.
     </p>
 
     <p>
-      There is another way, however, 
+      Although differences aside, JSX popularized the use of declarative inline
+      markup in components. This markup is more than just cheap template
+      compilation trickery as well. It supports dynamic interpolated values and
+      hierarchical composition. JSX had to be powerful to be useful, and any
+      alternatives must attain that requirement as well.
+    </p>
 
+    <p>
+      Lastly, while JSX is going to work perfectly fine for a majority of the
+      use cases encountered while working on small, medium, or complex
+      applications, it is not the only option for describing markup in code.
+    </p>
+    
     <a class="header" href="#transitions"><h3 id="transitions">Transitions</h3></a>
     <p>Coming soon...</p>
 

--- a/template.html
+++ b/template.html
@@ -539,5 +539,7 @@ middleware.unsubscribe = () => {
     ga('create', 'UA-27325220-4', 'auto');
     ga('send', 'pageview');
   </script>
+
+  <script async src="https://cdn.rawgit.com/tbranyen/diffhtml/master/dist/diffhtml.js"></script>
 </body>
 </html>

--- a/template.html
+++ b/template.html
@@ -214,7 +214,7 @@
             <th style="background-color: #FFF2CC;">Android Chrome (50)
         <tbody>
           <tr style="font-weight: bold; text-align: center;">
-            <td style="background-color: #F4CCCC;">✗
+            <td style="background-color: #CEE2DC;">✓
             <td style="background-color: #CEE2DC;">✓
             <td style="background-color: #CEE2DC;">✓
             <td style="background-color: #CEE2DC;">✓


### PR DESCRIPTION
Missing:
- Notes about inspiration from yo-yo and bel.
- Break down of features
  - Simple template helpers (HTML parsing)
    
    ``` js
    html`<div>Hello world</div>`
    ```
  - Nested template helpers
    
    ``` js
    html`<div>${html`<span>Hello world</span>`}</div>`
    ```
  - Escaped input
    
    ``` js
    html`<input value=${"<script>window.alert('This will not work');</script>"}>`
    ```
  - Parsing input
    
    ``` js
    html`<input value=${html("<script>window.alert('This will work');</script>")}>`
    // Haha, j/k you can't nest an element in a value property, but this will set the value to '[object Object]', the `toString` of the DOM Node
    ```
  - Nesting existing DOM Nodes
    
    ``` js
    html`<html>
      ${document.head}
      ${document.body}
    </html>`
    ```
  - Binding events
    
    ``` js
    const onClick = ev => console.log('Clicked %o', ev.target);
    
    html`<div onclick=${onClick}>
     Click to test...
    </div>`
    ```
